### PR TITLE
fixing API building helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed issue with URL generation in `Get-ModuleApiEndpoint` function to correctly
   include API prefix.
+- Fixing typo in `Import-ModuleApiEndpoint` function documentation. ([#3])
+- Fixed bug in `Get-HttpMethodFromPSVerb` function to correctly map PowerShell
+  verbs to HTTP methods.
+- Fixed issue with `ApiPrefix` property not being applied correctly in URL generation.
+- Fixed issue where `Authentication` property in `APIEndpoint` attribute was not
+working.
 
 ### Added
 
@@ -16,3 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adding `Import-ModuleApiEndpoint` function to import API endpoints from a module.
 - Adding `Get-HttpMethodFromPSVerb` function to convert PowerShell verbs to HTTP
   methods (GET, POST, PUT, DELETE).
+- Adding support for `Documentation` property in API endpoint metadata. ([#2](https://github.com/SynEdgy/synedgy.universal.helper/issues/2))
+- Adding `ApiPrefix` and `Version` properties to `APIEndpoint` attribute for better
+  URL structuring.
+- Adding `[APIInput]` and `[APIOutput]` attributes for defining input and output
+  schemas for API endpoint documentation (Not yet implemented).

--- a/build.yaml
+++ b/build.yaml
@@ -74,8 +74,9 @@ BuildWorkflow:
 
   publish:
     - Publish_Release_To_GitHub # Runs first, if token is expired it will fail early
-
     - publish_module_to_gallery
+    # - Publish_GitHub_Wiki_Content
+    # - Create_ChangeLog_GitHub_PR # is called in the Azure Pipeline Yaml after a successful publish
 
 ####################################################
 #       PESTER  Configuration                      #

--- a/source/Classes/00.Attributes/APIEndpoint.ps1
+++ b/source/Classes/00.Attributes/APIEndpoint.ps1
@@ -3,7 +3,8 @@ class APIEndpoint : System.Attribute
     [bool]$IsEndpoint = $true # Indicates that this is an API endpoint attribute
     [bool]$AutoSerialization = $true # Whether the endpoint should automatically serialize the output to JSON
     [string]$Name
-    [string]$version = 'v1' # Version of the API endpoint
+    [string]$ApiPrefix = 'api' # Prefix for the API endpoint URL
+    [string]$Version = 'v1' # Version of the API endpoint
     [string]$Path # aka the URL path of the endpoint
     [string]$Description # Description of the endpoint
     [ValidateSet('GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD')]

--- a/source/Classes/00.Attributes/APIInput.ps1
+++ b/source/Classes/00.Attributes/APIInput.ps1
@@ -1,0 +1,11 @@
+using namespace System.Net
+
+class APIInput : System.Attribute
+{
+    # APIInput() attribute used to specify type used for an API endpoint as input.
+    [HttpStatusCode] $StatusCode = [HttpStatusCode]::OK
+    [bool] $Required = $false
+    [string] $Description
+    [string] $Type
+    [string] $ContentType = 'application/json'
+}

--- a/source/Classes/00.Attributes/APIOutput.ps1
+++ b/source/Classes/00.Attributes/APIOutput.ps1
@@ -1,0 +1,11 @@
+using namespace System.Net
+
+class APIOutput : System.Attribute
+{
+    # APIOutput() attribute used to specify type used for an API endpoint as output.
+    [HttpStatusCode] $StatusCode = [HttpStatusCode]::OK
+    [string] $Description
+    [string] $Type
+    [string] $ContentType = 'application/json'
+
+}

--- a/source/Classes/00.Attributes/Documentation.ps1
+++ b/source/Classes/00.Attributes/Documentation.ps1
@@ -1,0 +1,4 @@
+class Documentation : System.Attribute
+{
+    # Documentation() attribute used to specify type used for an API endpoint as output or input.
+}

--- a/source/Public/Get-ModuleApiEndpointScriptblock.ps1
+++ b/source/Public/Get-ModuleApiEndpointScriptblock.ps1
@@ -41,8 +41,9 @@ function Get-ModuleApiEndpointScriptblock
         $startOffSet = $parameter.Name.Extent.StartOffset - $paramBlock.Extent.StartOffset
         $paramBlockStr = $paramBlockStr.Remove($startOffSet,$newParamName.Length).Insert($startOffSet,$newParamName)
 
-        #TODO: Change switch parameter to bool
+        #TODO: Change switch parameter to bool if PSU prefers that
     }
+    #TODO: Add the Inputs/Outputs documentation to the CBH section
     #endregion
 
     if ($PSBoundParameters.ContainsKey('Environment'))

--- a/source/Public/Import-PSUEndpoint.ps1
+++ b/source/Public/Import-PSUEndpoint.ps1
@@ -17,6 +17,12 @@ function Import-PSUEndpoint
         $ApiPrefix,
 
         [Parameter()]
+        [string]
+        # Name of the documentation endpoint to use for this endpoint.
+        # If not specified, the one defined by the attribute will be used, or the default one.
+        $Documentation,
+
+        [Parameter()]
         [switch]
         # Force authentication on the endpoint regardless of its configuration.
         $Authentication,
@@ -52,6 +58,11 @@ function Import-PSUEndpoint
     if ($PSBoundParameters.ContainsKey('LogLevel'))
     {
         $moduleApiEndpointParams['LogLevel'] = $LogLevel
+    }
+
+    if ($PSBoundParameters.ContainsKey('Documentation'))
+    {
+        $moduleEndpointScriptblockParameters['Documentation'] = $Documentation
     }
 
     $endpoints = Get-ModuleApiEndpoint @moduleApiEndpointParams

--- a/source/suffix.ps1
+++ b/source/suffix.ps1
@@ -3,6 +3,9 @@
 # If classes/types are specified here, they won't be fully qualified (careful with conflicts)
 $typesToExportAsIs = @(
     'APIEndpoint'
+    'Documentation'
+    'APIInput'
+    'APIOutput'
 )
 
 # The type accelerators created will be ModuleName.ClassName (to avoid conflicts with other modules until you use 'using moduleName'


### PR DESCRIPTION
# Pull Request

## Fixed

- Fixed issue with URL generation in `Get-ModuleApiEndpoint` function to correctly
  include API prefix.
- Fixed issue with `ApiPrefix` property not being applied correctly in URL generation.
- Fixed issue where `Authentication` property in `APIEndpoint` attribute was not
honoured.

## Added

- Adding support for `Documentation` property in API endpoint metadata. ([#2](https://github.com/SynEdgy/synedgy.universal.helper/issues/2))
- Adding `ApiPrefix` and `Version` properties to `APIEndpoint` attribute for better
  URL structuring.
- Adding `[APIInput]` and `[APIOutput]` attributes for defining input and output
  schemas for API endpoint documentation (Not yet implemented).
