### PR TITLE
fixing copyright image synedgy

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ consuming projects (e.g. ComsolCentral, PSUConfig):
 Both components rely on private helpers (`ConvertFrom-PsuJobOutputEntry`, `Convert-AnsiToHtml`,
 `Convert-PlainTextToHtml`, `Get-UDPsuJobThemePalette`, `Get-UDPsuJobThemeStyleBlock`,
 `ConvertTo-UDPsuThemedIconMarkup`) and branding assets under `images/synedgy_pwsh/` that ship with
-this module -- consuming projects do not need to duplicate them.
+this module -- consuming projects do not need to duplicate them. See
+`images/synedgy_pwsh/COPYRIGHT.md` for the copyright/usage notice covering that artwork.
 
 ### Usage
 

--- a/source/images/synedgy_pwsh/COPYRIGHT.md
+++ b/source/images/synedgy_pwsh/COPYRIGHT.md
@@ -1,0 +1,11 @@
+# Copyright Notice: images/synedgy_pwsh
+
+The icon artwork under `source/images/synedgy_pwsh/` (`pwsh_custom_*.svg`) is a custom
+SynEdgy-branded design based on the terminal prompt symbol (`>_`), styled using SynEdgy's own
+logo and brand movement/identity.
+
+Copyright (c) SynEdgy. All rights reserved.
+
+These images are provided for use within this module and by consuming projects that declare
+`synedgy.universal.helper` as a dependency. They are not licensed for reuse, redistribution, or
+modification outside of that context without prior written permission from SynEdgy.


### PR DESCRIPTION
This pull request primarily adds a copyright and usage notice for the SynEdgy-branded icon artwork included in the module. It also updates the documentation to reference this new notice, clarifying the terms under which the images may be used.

Documentation updates:

* Updated the `README.md` to reference the copyright/usage notice for the artwork in `images/synedgy_pwsh/`, directing users to `COPYRIGHT.md` for details.

Legal/compliance:

* Added a new `COPYRIGHT.md` file under `source/images/synedgy_pwsh/` specifying the copyright ownership, permitted usage, and restrictions for the SynEdgy-branded icon images.