### PR TITLE
fixing synedgy terminal logo by theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed the themed icon (top-right/title-bar `>_` icon) in `New-UDPsuJobHeader` and
+  `New-UDPsuJobTerminalView` always rendering the light (black) variant regardless
+  of PSU's active theme when `-Theme Auto` (the default). `ConvertTo-UDPsuThemedIconMarkup`
+  was setting the light/dark icon spans' default visibility via an inline `style`
+  attribute, which always takes precedence over stylesheet rules regardless of CSS
+  specificity -- so `Get-UDPsuJobThemeStyleBlock`'s `html[data-theme="dark"]` override
+  rule could never actually flip visibility. The default and dark-mode-override
+  display rules are now both defined in the `<style>` block instead, so the icon
+  correctly switches color when the PSU theme switch is toggled live.
 - Fixed how the ApiVersion is set and can be overridden.
 - Fixed how the Documentation is set and can be overridden.
 

--- a/source/Private/ConvertTo-UDPsuThemedIconMarkup.ps1
+++ b/source/Private/ConvertTo-UDPsuThemedIconMarkup.ps1
@@ -87,14 +87,21 @@ function ConvertTo-UDPsuThemedIconMarkup
             $lightSvg = & $renderSvg $blackSvgPath ($IdPrefix + '-lt') $ExtraStyle
             $darkSvg  = & $renderSvg $whiteSvgPath ($IdPrefix + '-dk') $ExtraStyle
 
+            # NOTE: default show/hide state is intentionally NOT set via an inline `style`
+            # attribute here. Inline styles always win over stylesheet rules regardless of
+            # selector specificity, so Get-UDPsuJobThemeStyleBlock's `html[data-theme="dark"]`
+            # override rules would never be able to flip visibility if it were set inline.
+            # The default (light-ambient) display state is instead defined as a plain CSS rule
+            # in Get-UDPsuJobThemeStyleBlock, alongside the dark-mode override, so both states
+            # live in the stylesheet and the cascade works as expected.
             $markup = ''
             if ($lightSvg)
             {
-                $markup += '<span class="psu-theme-light-only" style="display:contents;">' + $lightSvg + '</span>'
+                $markup += '<span class="psu-theme-light-only">' + $lightSvg + '</span>'
             }
             if ($darkSvg)
             {
-                $markup += '<span class="psu-theme-dark-only" style="display:none;">' + $darkSvg + '</span>'
+                $markup += '<span class="psu-theme-dark-only">' + $darkSvg + '</span>'
             }
             return $markup
         }

--- a/source/Private/Get-UDPsuJobThemeStyleBlock.ps1
+++ b/source/Private/Get-UDPsuJobThemeStyleBlock.ps1
@@ -67,6 +67,8 @@ function Get-UDPsuJobThemeStyleBlock
         {
             (
                 ('#{0} {{ {1} }}' -f $ElementId, (& $toVarsCss $palette.Light)) +
+                ('#{0} .psu-theme-light-only {{ display:contents; }}' -f $ElementId) +
+                ('#{0} .psu-theme-dark-only {{ display:none; }}' -f $ElementId) +
                 ('html[data-theme="dark"] #{0} {{ {1} }}' -f $ElementId, (& $toVarsCss $palette.Dark)) +
                 ('html[data-theme="dark"] #{0} .psu-theme-light-only {{ display:none; }}' -f $ElementId) +
                 ('html[data-theme="dark"] #{0} .psu-theme-dark-only {{ display:contents; }}' -f $ElementId)

--- a/source/WikiSource/PSU-Platform-Notes.md
+++ b/source/WikiSource/PSU-Platform-Notes.md
@@ -34,6 +34,13 @@ apps that consume it.
 - `New-PSUScript`/`New-PSUAiTool`/`New-PSUEndpoint` are idempotent when called repeatedly with the
   same identifying parameters (module/command, name, etc.), which is why `Import-PSUEndpoint` and
   `Import-PSUAiTool` can be safely re-run on every PSU config reload.
+- PSU's module install is keyed by version string. Redeploying a module with an unchanged version
+  (e.g. local uncommitted fixes, since GitVersion computes the version from commit history, not
+  working tree state) silently skips extracting new content -- `pack`/`deploy` report success with
+  no errors, but the stale code keeps running. During local iteration on uncommitted changes,
+  force a fresh install by setting a unique `$env:ModuleVersion` (e.g. append a timestamp/dev
+  suffix) before `pack`, or verify by checking the deployed file's timestamp/content directly under
+  `C:\ProgramData\UniversalAutomation\Repository\Modules\<Module>\<Version>\`.
 
 ## Theming
 


### PR DESCRIPTION
This pull request fixes an issue with the themed icon in the job header and terminal view components not responding to PSU's active theme, and improves the theming logic for icon rendering. It also updates documentation to clarify module redeployment behavior when the version string doesn't change.

**Theming and Icon Rendering Improvements:**

* The themed icon in `New-UDPsuJobHeader` and `New-UDPsuJobTerminalView` now correctly switches between light and dark variants when the PSU theme is toggled. Previously, inline `style` attributes prevented CSS overrides from working; now, display rules are defined in the stylesheet instead.
* In `ConvertTo-UDPsuThemedIconMarkup.ps1`, removed inline `style` attributes from icon markup to allow CSS-based theming to function as intended.
* In `Get-UDPsuJobThemeStyleBlock.ps1`, added CSS rules for `.psu-theme-light-only` and `.psu-theme-dark-only` classes to control icon visibility based on theme, ensuring proper switching.

**Documentation Updates:**

* Updated platform notes to explain that redeploying a module with an unchanged version string does not extract new content, which can lead to stale code running. Provided guidance for forcing a fresh install during local development.