### PR TITLE
fixing wiki link

### DIFF
--- a/.github/instructions/wiki-publishing.instructions.md
+++ b/.github/instructions/wiki-publishing.instructions.md
@@ -23,6 +23,7 @@ applyTo: 'source/WikiSource/**/*.md,build.yaml,.pipelines/*.yml,.pipelines/*.yam
 - Put landing-page content in `source/WikiSource/Home.md` when a custom wiki home page is needed.
 - If `Home.md` contains module version placeholders, rely on the Sampler/DscResource.DocGenerator task to update them during the build; do not hardcode release-specific versions into committed wiki pages.
 - Keep custom wiki content in Markdown that is compatible with GitHub wiki rendering.
+- Internal wiki links must omit the `.md` extension (e.g. `[UD Job Components](UD-Job-Components)`, not `(UD-Job-Components.md)`). GitHub wiki pages are served at extension-less URLs; a link with `.md` navigates to the raw file view instead of the rendered page. Match the extension-less convention already used by the auto-generated `_Sidebar.md`.
 
 ## Validation
 

--- a/source/WikiSource/AI-Tool-Attribute.md
+++ b/source/WikiSource/AI-Tool-Attribute.md
@@ -2,7 +2,7 @@
 
 `synedgy.universal.helper` also ships an `AiTool` class attribute, a `[System.Attribute]` you can
 put on any public function in a consuming module to expose it as a PowerShell Universal AI tool,
-mirroring the [API Endpoint Attribute](API-Endpoint-Attribute.md) pattern used for REST endpoints:
+mirroring the [API Endpoint Attribute](API-Endpoint-Attribute) pattern used for REST endpoints:
 
 ```powershell
 function Find-UserByCity

--- a/source/WikiSource/API-Endpoint-Attribute.md
+++ b/source/WikiSource/API-Endpoint-Attribute.md
@@ -67,6 +67,6 @@ scriptblock directly.
 
 `New-PSUEndpoint` accepts an inline `-Endpoint {scriptblock}` parameter, so `Import-PSUEndpoint`
 can synthesize a wrapper scriptblock dynamically and register the endpoint in one step. This is
-different from the [AI Tool Attribute](AI-Tool-Attribute.md) pattern, where `New-PSUAiTool` only
+different from the [AI Tool Attribute](AI-Tool-Attribute) pattern, where `New-PSUAiTool` only
 accepts `-ScriptFullPath` referencing an already-registered PSU Script resource, so
 `Import-PSUAiTool` must also declare that backing script.

--- a/source/WikiSource/Home.md
+++ b/source/WikiSource/Home.md
@@ -4,13 +4,13 @@ A bunch of PowerShell Universal (PSU) helpers to make your experience more produ
 
 ## Start here
 
-- [UD Job Components](UD-Job-Components.md) - shared Universal Dashboard components for
+- [UD Job Components](UD-Job-Components) - shared Universal Dashboard components for
   rendering PSU job status/output, with light/dark theming.
-- [API Endpoint Attribute](API-Endpoint-Attribute.md) - declaratively expose module functions as
+- [API Endpoint Attribute](API-Endpoint-Attribute) - declaratively expose module functions as
   PSU REST API endpoints with `[APIEndpoint()]` and `Import-PSUEndpoint`.
-- [AI Tool Attribute](AI-Tool-Attribute.md) - declaratively expose module functions as PSU AI
+- [AI Tool Attribute](AI-Tool-Attribute) - declaratively expose module functions as PSU AI
   tools (MCP) with `[AiTool()]` and `Import-PSUAiTool`.
-- [PSU Platform Notes](PSU-Platform-Notes.md) - known PowerShell Universal platform behaviors and
+- [PSU Platform Notes](PSU-Platform-Notes) - known PowerShell Universal platform behaviors and
   gotchas worth knowing when building on top of this module or consuming PSU apps.
 
 ## Command reference


### PR DESCRIPTION
This pull request improves the consistency and correctness of internal wiki links throughout the documentation. The main focus is on ensuring that all internal links omit the `.md` extension, which aligns with GitHub wiki conventions and prevents navigation to raw file views.

Wiki link formatting improvements:

* Updated all internal wiki links in `Home.md`, `API-Endpoint-Attribute.md`, and `AI-Tool-Attribute.md` to remove the `.md` extension, ensuring links point to the rendered wiki pages instead of the raw Markdown files. [[1]](diffhunk://#diff-4ff689846f9c896ab4e3598f4348bcdd256f5966427b380618864283b182ff93L7-R13) [[2]](diffhunk://#diff-17c4188ad706eb8ad7a6dee7095efdea3494e1ca8141308dec3c5b37b790a902L70-R70) [[3]](diffhunk://#diff-48320c43930b0c8873f3f4f8860f40039f241f8fbe80adac13c296ea823df5afL5-R5)
* Added an explicit instruction to `.github/instructions/wiki-publishing.instructions.md` requiring that internal wiki links omit the `.md` extension, with an example and rationale.