### PR TITLE
fix AITools and make sure it does not override already set tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `Import-PSUAiTool` leaking `New-PSUScript`'s return object onto its output
+  pipeline alongside the intended `New-PSUAiTool` result. Since a module's
+  `.universal/aiTools.ps1` resource file is expected by PSU to emit only `AiTool`
+  objects, the leaked `PowerShellUniversal.Script` object caused PSU to fail
+  loading the configuration with `Cannot convert the "<Module>\<Command>" value of
+  type "PowerShellUniversal.Script" to type
+  "PowerShellUniversal.Models.Intelligence.AiTool"`, silently preventing all AI
+  tools declared in that file from registering. `New-PSUScript`'s result is now
+  suppressed with `$null =`.
+- Changed `Import-PSUAiTool` to only create a backing PSU Script when one doesn't
+  already exist for the `<Module>\<Command>` identity (via `Get-PSUScript`), instead
+  of unconditionally re-declaring it on every config reload. A script may already be
+  explicitly declared elsewhere (e.g. `scripts.ps1`) with more specific settings
+  (Role, Timeout, Tags, etc.); the previous unconditional call would have silently
+  overwritten that configuration with a bare-bones one every time PSU reloaded its
+  config.
 - Fixed the themed icon (top-right/title-bar `>_` icon) in `New-UDPsuJobHeader` and
   `New-UDPsuJobTerminalView` always rendering the light (black) variant regardless
   of PSU's active theme when `-Theme Auto` (the default). `ConvertTo-UDPsuThemedIconMarkup`

--- a/source/Public/Import-PSUAiTool.ps1
+++ b/source/Public/Import-PSUAiTool.ps1
@@ -10,10 +10,13 @@ function Import-PSUAiTool
         resource exists (New-PSUScript, keyed by <Module>\<Command>) and registers the
         corresponding AI tool (New-PSUAiTool). Unlike Import-PSUEndpoint, which builds an
         inline wrapper scriptblock for New-PSUEndpoint, New-PSUAiTool requires an existing
-        Script resource referenced by its ScriptFullPath, so this function always
-        (re-)declares that backing script alongside the AI tool. Both New-PSUScript and
-        New-PSUAiTool are idempotent when called repeatedly with the same identity, which
-        is safe since PSU resource declaration files are re-executed on every config
+        Script resource referenced by its ScriptFullPath. The backing script is only
+        created when one doesn't already exist for that identity -- if it was already
+        explicitly declared elsewhere (e.g. scripts.ps1) with more specific settings
+        (Role, Timeout, Tags, etc.), that declaration is left untouched rather than
+        being overwritten by this bare-bones one on every config reload. New-PSUAiTool
+        itself is idempotent when called repeatedly with the same identity, which is
+        safe since PSU resource declaration files are re-executed on every config
         reload.
 
         .PARAMETER Module
@@ -81,18 +84,39 @@ function Import-PSUAiTool
     $aiTools | ForEach-Object -Process {
         $aiTool = $_
 
-        $newScriptParams = @{
-            Module  = $Module
-            Command = $aiTool.FunctionInfo.Name
-        }
-        if ($aiTool.ContainsKey('Environment'))
+        # Only create a backing PSU Script when one doesn't already exist for this
+        # <Module>\<Command> identity. A script may already be explicitly declared
+        # elsewhere (e.g. scripts.ps1) with more specific settings (Role, Timeout,
+        # Tags, etc.); blindly re-declaring it here on every config reload would
+        # overwrite that more specific configuration with this bare-bones one.
+        # NOTE: uses try/catch rather than -ErrorAction SilentlyContinue -- the
+        # latter is reliably observed to prevent Pester from routing this call
+        # through a Mock when invoked from this already-compiled function body,
+        # making the "already exists" branch untestable without a live PSU server.
+        try
         {
-            $newScriptParams['Environment'] = $aiTool.Environment
+            $existingScript = Get-PSUScript -Name $aiTool.ScriptFullPath
+        }
+        catch
+        {
+            $existingScript = $null
         }
 
-        if ($PSCmdlet.ShouldProcess(('Registering backing PSU Script for AI tool {0}: {1}' -f $aiTool.Name, ($newScriptParams | ConvertTo-Json -Compress))))
+        if (-not $existingScript)
         {
-            New-PSUScript @newScriptParams
+            $newScriptParams = @{
+                Module  = $Module
+                Command = $aiTool.FunctionInfo.Name
+            }
+            if ($aiTool.ContainsKey('Environment'))
+            {
+                $newScriptParams['Environment'] = $aiTool.Environment
+            }
+
+            if ($PSCmdlet.ShouldProcess(('Registering backing PSU Script for AI tool {0}: {1}' -f $aiTool.Name, ($newScriptParams | ConvertTo-Json -Compress))))
+            {
+                $null = New-PSUScript @newScriptParams
+            }
         }
 
         $newAiToolParams = @{

--- a/tests/Unit/Public/Import-PSUAiTool.Tests.ps1
+++ b/tests/Unit/Public/Import-PSUAiTool.Tests.ps1
@@ -74,4 +74,50 @@ Describe 'Import-PSUAiTool' {
             synedgy.universal.helper\Import-PSUAiTool -Module $script:testModuleName -WhatIf -ErrorAction Stop
         } | Should -Not -Throw
     }
+
+    It 'Should not overwrite an already-existing backing PSU Script' {
+        InModuleScope -Parameters @{ TestModuleName = $script:testModuleName } -ScriptBlock {
+            param($TestModuleName)
+
+            # Stub functions for the real PowerShell Universal 'Universal' module cmdlets,
+            # which are not installed in this test environment (build agents don't have
+            # PSU installed). These must be defined here, in this same InModuleScope
+            # invocation, immediately before Mock -- function definitions from a separate
+            # InModuleScope call do not persist into this one, and Pester's Mock cannot
+            # create a mock for a command that isn't resolvable at all.
+            function Get-PSUScript { [CmdletBinding()] param([string] $Name) }
+            function New-PSUScript { [CmdletBinding()] param([object] $Module, [string] $Command, [string] $Environment) }
+            function New-PSUAiTool { [CmdletBinding()] param([string] $Name, [string] $Description, [string] $ScriptFullPath, [bool] $Authenticated, [string[]] $Role, [bool] $Mcp) }
+
+            Mock -CommandName 'Get-PSUScript' -MockWith { [pscustomobject]@{ FullPath = 'ImportPSUAiToolTestModule\Test-ImportAiToolSampleCommand' } }
+            Mock -CommandName 'New-PSUScript' -MockWith { }
+            Mock -CommandName 'New-PSUAiTool' -MockWith { }
+
+            Import-PSUAiTool -Module $TestModuleName -Confirm:$false
+
+            Should -Invoke -CommandName 'Get-PSUScript' -Times 1 -Exactly
+            Should -Invoke -CommandName 'New-PSUScript' -Times 0 -Exactly
+            Should -Invoke -CommandName 'New-PSUAiTool' -Times 1 -Exactly
+        }
+    }
+
+    It 'Should create a backing PSU Script when one does not already exist' {
+        InModuleScope -Parameters @{ TestModuleName = $script:testModuleName } -ScriptBlock {
+            param($TestModuleName)
+
+            function Get-PSUScript { [CmdletBinding()] param([string] $Name) }
+            function New-PSUScript { [CmdletBinding()] param([object] $Module, [string] $Command, [string] $Environment) }
+            function New-PSUAiTool { [CmdletBinding()] param([string] $Name, [string] $Description, [string] $ScriptFullPath, [bool] $Authenticated, [string[]] $Role, [bool] $Mcp) }
+
+            Mock -CommandName 'Get-PSUScript' -MockWith { $null }
+            Mock -CommandName 'New-PSUScript' -MockWith { }
+            Mock -CommandName 'New-PSUAiTool' -MockWith { }
+
+            Import-PSUAiTool -Module $TestModuleName -Confirm:$false
+
+            Should -Invoke -CommandName 'Get-PSUScript' -Times 1 -Exactly
+            Should -Invoke -CommandName 'New-PSUScript' -Times 1 -Exactly
+            Should -Invoke -CommandName 'New-PSUAiTool' -Times 1 -Exactly
+        }
+    }
 }


### PR DESCRIPTION
This pull request fixes a critical bug in the `Import-PSUAiTool` function that previously caused PowerShell Universal (PSU) to fail loading AI tool configurations, and improves its behavior to avoid overwriting existing script configurations. It also adds new unit tests to ensure correct handling of backing scripts for AI tools.

**Bug fixes and behavior improvements:**

* Fixed `Import-PSUAiTool` leaking the return object from `New-PSUScript` onto its output pipeline, which previously caused PSU to fail loading AI tool configurations due to type mismatches. The result from `New-PSUScript` is now suppressed. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR66-R81) [[2]](diffhunk://#diff-581de9d2c4a224fdb9e962f65774683227eb89a7261896418126f9350a4f4ce8L95-R119)
* Changed `Import-PSUAiTool` to only create a new backing PSU Script if one does not already exist for the given `<Module>\<Command>` identity, preventing accidental overwrites of more specific script configurations on config reloads. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR66-R81) [[2]](diffhunk://#diff-581de9d2c4a224fdb9e962f65774683227eb89a7261896418126f9350a4f4ce8L13-R19) [[3]](diffhunk://#diff-581de9d2c4a224fdb9e962f65774683227eb89a7261896418126f9350a4f4ce8R87-R106) [[4]](diffhunk://#diff-581de9d2c4a224fdb9e962f65774683227eb89a7261896418126f9350a4f4ce8L95-R119)

**Testing improvements:**

* Added unit tests to verify that `Import-PSUAiTool` does not overwrite an existing backing script and does create one when needed. These tests use mocks to simulate PSU cmdlets and ensure correct invocation logic.